### PR TITLE
Adding fixes to compile on Arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9)
 
 project(PathTracer LANGUAGES CXX C)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(OpenMP)

--- a/src/path_tracer.cpp
+++ b/src/path_tracer.cpp
@@ -109,7 +109,7 @@ void PathTracer::Render( Scene* scene )
     auto antiAliasAlg        = AntiAlias::GetAlgorithm( cam.aaAlgorithm );
     auto antiAliasIterations = AntiAlias::GetIterations( cam.aaAlgorithm );
 
-    std::atomic< int > renderProgress = 0;
+    std::atomic< int > renderProgress(0);
     int onePercent = static_cast< int >( std::ceil( renderedImage.GetHeight() / 100.0f ) );
 
     #pragma omp parallel for schedule( dynamic )


### PR DESCRIPTION
std::make_unique requires C++14.
The atomic<int> copy constructor is deleted.